### PR TITLE
Fix Invalid Filter Error on Add Client Form

### DIFF
--- a/commissions/templatetags/__init__.py
+++ b/commissions/templatetags/__init__.py
@@ -1,0 +1,1 @@
+# This file marks the directory as a Python package.

--- a/commissions/templatetags/__init__.py
+++ b/commissions/templatetags/__init__.py
@@ -1,1 +1,1 @@
-# This file marks the directory as a Python package.
+"""Mark the commissions.templatetags package as a Python package."""

--- a/commissions/templatetags/form_extras.py
+++ b/commissions/templatetags/form_extras.py
@@ -1,0 +1,14 @@
+from django import template
+
+register = template.Library()
+
+@register.filter(name="add_class")
+def add_class(field, css_classes):
+    """
+    Django template filter to add CSS classes to a form field widget,
+    merging with any existing classes.
+    Usage in template: {{ field|add_class:"class1 class2" }}
+    """
+    existing_classes = field.field.widget.attrs.get("class", "")
+    classes = f"{existing_classes} {css_classes}".strip() if existing_classes else css_classes
+    return field.as_widget(attrs={"class": classes})

--- a/commissions_tracker/settings.py
+++ b/commissions_tracker/settings.py
@@ -64,6 +64,7 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
             ],
+            'builtins': ['commissions.templatetags.form_extras'],
         },
     },
 ]


### PR DESCRIPTION
This pull request addresses the `TemplateSyntaxError` encountered when attempting to add a client. The error stemmed from the missing 'add_class' filter in the Django template. 

### Changes Made:
1. **Custom Template Tag:** A new template tag (`add_class`) has been added in `commissions/templatetags/form_extras.py`. This filter allows the addition of CSS classes to form field widgets by merging them with existing classes.
2. **Template Registration:** The `commissions/templatetags/__init__.py` file was created to mark the directory as a Python package, enabling Django to recognize the custom template tags.
3. **Settings Update:** The `builtins` option in `TEMPLATES` settings in `commissions_tracker/settings.py` has been updated to include our new template tag so it can be used in any templates without needing to load it explicitly.

### How to Use:
With the added filter, you can now add classes to your form inputs in the `client_form.html` template. For instance:  
`<input>{{ form.nickname|add_class:"form-control" }}>`  
This should prevent the `TemplateSyntaxError` from occurring when rendering the form.

---

> This pull request was co-created with Cosine Genie

Original Task: [Commtracker/gnn2ve8zjcgb](https://cosine.sh/uyj0k4lc37n5/Commtracker/task/gnn2ve8zjcgb)
Author: Gote Mazzy
