### PR TITLE
Fix ValueError for Invalid Client ID in Client List View

### DIFF
--- a/commissions/views.py
+++ b/commissions/views.py
@@ -72,17 +72,29 @@ def client_list(request):
     selected_client = None
     client_note_form = None
     notes = None
+
+    # Validate selected_pk to be a proper integer (or None)
+    valid_selected_pk = None
     if selected_pk:
-        selected_client = Client.objects.filter(pk=selected_pk).first()
+        # Sometimes selected_pk can be of the form '1?selected=1'; take only the numeric part
+        raw_pk = selected_pk.split('?')[0].split('&')[0]
+        try:
+            valid_selected_pk = int(raw_pk)
+        except (ValueError, TypeError):
+            valid_selected_pk = None
+
+    if valid_selected_pk is not None:
+        selected_client = Client.objects.filter(pk=valid_selected_pk).first()
         if selected_client:
             notes = selected_client.client_notes.all().order_by('-created_at')
             client_note_form = ClientNoteForm()
+
     return render(request, 'commissions/client_list.html', {
         'clients': clients,
         'selected_client': selected_client,
         'client_note_form': client_note_form,
         'notes': notes,
-        'selected_pk': selected_pk,
+        'selected_pk': valid_selected_pk,
     })
 
 def client_create(request):


### PR DESCRIPTION
This pull request addresses the issue of a `ValueError` encountered when accessing the `/clients/` endpoint. The problem arose from improperly formatted query parameters (e.g., `1?selected=1`), which led to a failed attempt to convert the `id` to an integer.

### Changes Made:
- Updated the `client_list` view in `commissions/views.py` to sanitize the `selected_pk`. The new logic extracts the numeric portion of the `selected_pk` by splitting on both `?` and `&`, ensuring only the integer value is processed.
- Added a try-except block to handle any potential `ValueError` or `TypeError` that may result from invalid inputs, setting `valid_selected_pk` to `None` in such cases.
- Modified the condition to filter `Client` objects based on the valid `selected_pk`, thus preventing the application from crashing when the input is invalid.

This fix ensures a smoother user experience by properly handling edge cases in URL queries.

---

> This pull request was co-created with Cosine Genie

Original Task: [Commtracker/zhgvp29uxnik](https://cosine.sh/uyj0k4lc37n5/Commtracker/task/zhgvp29uxnik)
Author: Gote Mazzy
