### PR TITLE
Fix redirect after creating clients and commissions

### DIFF
--- a/commissions/views.py
+++ b/commissions/views.py
@@ -111,7 +111,8 @@ def client_create(request):
         if form.is_valid():
             client = form.save()
             messages.success(request, "Client created successfully.")
-            return redirect('commissions:client_detail', pk=client.pk)
+            # Redirect to the list view with new client selected
+            return redirect(f'/commissions/clients/?selected={client.pk}')
         else:
             messages.error(request, "Please correct the errors below.")
     else:
@@ -140,7 +141,8 @@ def commission_create_for_client(request, pk):
             commission.save()
             form.save_m2m()
             messages.success(request, "Commission created and assigned to client.")
-            return redirect('commissions:commission_detail', pk=commission.pk)
+            # Redirect to the commissions list with new commission selected
+            return redirect(f'/commissions/?selected={commission.pk}')
         else:
             messages.error(request, "Please correct the errors below.")
     else:


### PR DESCRIPTION
This PR updates the redirect logic in the `commissions/views.py` file to ensure that after a client or commission is created, the user is redirected to the respective list view with the new item selected. Instead of showing a full screen empty view, it now properly opens the list panel followed by the details of the selected item. This enhances the user experience by providing immediate feedback and access to the created item.

---

> This pull request was co-created with Cosine Genie

Original Task: [Commtracker/b1ipe0pr7v66](https://cosine.sh/uyj0k4lc37n5/Commtracker/task/b1ipe0pr7v66)
Author: Gote Mazzy
